### PR TITLE
Dev favicon fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ web_project/__pycache__/
 pierzada_app/migrations/__pycache__/
 todo.txt
 db.sqlite3
+web_project/wsgi.py

--- a/pierzada_app/templates/pierzada/layout.html
+++ b/pierzada_app/templates/pierzada/layout.html
@@ -5,7 +5,7 @@
     <title>{% block title %}{% endblock %}</title>
     {% load static %}
     <link rel="stylesheet" type="text/css" href="{% static 'pierzada/site.css' %}"/>
-    <link rel="icon" href="static/pierzada/favicon.ico">
+    <link rel="icon" href="{% static 'pierzada/favicon.ico' %}">
 </head>
 
 <body>


### PR DESCRIPTION
changed html link reference to find favicon.ico using relative path instead of absolute, which allows the same file to be used regardless of page